### PR TITLE
Add License

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@
 また、第 20 章以降は Rails Tutorial で作成したアプリケーションに対して実装していくので、先に Rails Tutorial を受けた人は自分の Rails Tutorial リポジトリに対して、そうでない人は課題提出リポジトリの `sample_app` ディレクトリに配置されているアプリケーションに対して実装し、 Pull Request を出してください。
 
 第 23 章のみ `sample_app` が独立したリポジトリでないと Heroku やマネクラに push できないと思いますので、その時は適宜 `sample_app` をコピーしたリポジトリを新規で作成してください。
+
+## Rail Tutorialのライセンス
+
+Ruby on Rails Tutorial: Learn Web Development with Rails. Copyright © 2014 by Michael Hartl.
+
+All source code in the Ruby on Rails Tutorial is available jointly under the MIT License and the Beerware License.
+
+Copyright &copy; 2014-2017 [Michael Hartl](https://www.michaelhartl.com/)

--- a/app_start/LICENSE
+++ b/app_start/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright &copy; 2015-2017 [YassLab](https://yasslab.jp)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Copy the [LICENSE](https://github.com/yasslab/sample_apps/blob/6ec7c9cc01587c6cf75fde033fefdbb202009dc5/LICENSE) to notice explicitly that the copyright to `sample_app` is reserved by YassLab.

We also notice that the copyright to Rails Tutorial itself is reserved by Michael Hartl.