### PR TITLE
20章「React on Rails をはじめる」節のディレクトリ 名のタイポを修正

### DIFF
--- a/docs/ch20/README.md
+++ b/docs/ch20/README.md
@@ -51,7 +51,7 @@ Rails Tutorial で作成した Micropost アプリケーションを SPA にし�
 
 `app/javascript/components/index.tsx` の中に書いていた `Showcase` コンポーネントはもう使わないので、削除するか適当なファイルにコピーして脇に置いておいてください。
 
-`app/javascripts/components/static-pages/Home.tsx` を作って以下のような内容にします:
+`app/javascript/components/static-pages/Home.tsx` を作って以下のような内容にします:
 
 ```tsx
 const Home = () => {
@@ -63,7 +63,7 @@ export default Home;
 
 （ Tips: これまで Ruby/Rails で開発してきたので、 `Home.tsx` とファイル名に大文字が入ることに違和感を感じるかもしれませんが、React や Vue でコンポーネントを作った時のファイル名はキャメルケースを使うことが多いです。）
 
-この `Home` コンポーネントを `app/javascripts/components/static-pages/index.ts` から提供する形にしましょう:
+この `Home` コンポーネントを `app/javascript/components/static-pages/index.ts` から提供する形にしましょう:
 
 ```ts
 import Home from "./Home";


### PR DESCRIPTION
「React on Rails をはじめる」節にて、作成するファイルを格納するディレクトリ名が単数形`app/javascript`と 複数形`app/javascripts`が混在していたので、単数系の方に統一してみました（統一させると動作しました）