### PR TITLE
Dealing with `turbolinks:load` event fired by turbolinks

### DIFF
--- a/app_goal/app/javascript/packs/application.js
+++ b/app_goal/app/javascript/packs/application.js
@@ -16,9 +16,17 @@ Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
 
-document.addEventListener("DOMContentLoaded", () => {
+const renderReactDOM = () => {
   const container = document.getElementById("app")
   if (container) {
     ReactDOM.render(<App />, container)
   }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  renderReactDOM()
+})
+
+document.addEventListener("turbolinks:load", () => {
+  renderReactDOM()
 })

--- a/docs/ch18/README.md
+++ b/docs/ch18/README.md
@@ -84,6 +84,11 @@ ActiveStorage.start()
 document.addEventListener("DOMContentLoaded", () => {
   ReactDOM.render(<App />, document.getElementById("app"))
 })
+
+// turbolinksによる画面遷移時は DOMContentLoaded ではなく turbolinks:load イベントが発火する
+document.addEventListener("turbolinks:load", () => {
+  ReactDOM.render(<App />, document.getElementById("app"))
+})
 ```
 
 [`ReactDOM.render`](https://ja.reactjs.org/docs/react-dom.html#render) という API を使っていますね。これで `id="app"` な DOM 要素の中に `App` を描画するのだ、というぐらいに思ってください。

--- a/docs/ch20/README.md
+++ b/docs/ch20/README.md
@@ -86,11 +86,19 @@ export default App;
 `<div id="app">` 要素はログイン時のみ存在するようにしたので、 `app/javascript/packs/application.js` ではその要素がある場合に限って `ReactDOM.render()` するように修正しましょう:
 
 ```js
-document.addEventListener("DOMContentLoaded", () => {
+const renderReactDOM = () => {
   const container = document.getElementById("app")
   if (container) {
     ReactDOM.render(<App />, container)
   }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  renderReactDOM()
+})
+
+document.addEventListener("turbolinks:load", () => {
+  renderReactDOM()
 })
 ```
 


### PR DESCRIPTION
Turbolinksが有効になっていると初回画面ロード時しか `DOMContentLoaded` イベントが発火せず、それ以降リンクをクリックした際の画面遷移はTrubolinksが間に入ってしまうので、例えばヘッダ部分の `root_path` へのリンクをクリックするとフィードが何も表示されない状態になってしまっていました。

Turbolinksによる画面遷移時はそれ専用の `turbolinks:load` イベントが発火するそうなので、そのイベントでも `ReactDOM.render()` するようにします。

cf. https://github.com/turbolinks/turbolinks#observing-navigation-events