### PR TITLE
axiosのresponse headersのkeyを小文字で指定する

### DIFF
--- a/docs/ch21/README.md
+++ b/docs/ch21/README.md
@@ -215,7 +215,7 @@ end
       });
 
       if (meta) {
-        meta.content = res.headers["X-CSRF-Token"];
+        meta.content = res.headers["x-csrf-token"];
       }
 
       props.onDelete(props.feed.id);


### PR DESCRIPTION
axiosの返却する `response.headers` オブジェクトは、キーが小文字で返却されることが手元の環境で確認されました。

これにあわせた内容をドキュメントに反映させることを提案します。