### PR TITLE
サブpathを含むURLもanyとしてルーティングさせる

### DIFF
--- a/app_goal/config/routes.rb
+++ b/app_goal/config/routes.rb
@@ -22,5 +22,7 @@ Rails.application.routes.draw do
   resources :feeds, only: [:index]
 
   # /rails 以下は特別な意味を持つので :any としてはルーティングさせない
-  get '*any', to: 'static_pages#home', constraints: { any: /(?<!rails)\w+/}
+  scope ':any', as: :any, constraints: { any: /(?!rails\/).*/ } do
+    root to: 'static_pages#home'
+  end
 end

--- a/docs/ch22/README.md
+++ b/docs/ch22/README.md
@@ -90,7 +90,9 @@ export default App;
 Rails.application.routes.draw do
   # 最終行に追加
   # ただし /rails 以下は特別な意味を持つので :any としてはルーティングさせない
-  get '*any', to: 'static_pages#home', constraints: { any: /(?<!rails)\w+/}
+  scope ':any', as: :any, constraints: { any: /(?!rails\/).*/ } do
+    root to: 'static_pages#home'
+  end
 end
 ```
 


### PR DESCRIPTION
pathが1階層だけであれば `any` としてルーティングできていたのですが `/foo/bar` のようにサブの階層があるURLだと正しくルーティングできていなかったので修正します。